### PR TITLE
page_table: allow more generic virtual addresses in page table

### DIFF
--- a/page_table_multiarch/src/arch/aarch64.rs
+++ b/page_table_multiarch/src/arch/aarch64.rs
@@ -1,7 +1,6 @@
 //! AArch64 specific page table structures.
 
 use core::arch::asm;
-use memory_addr::VirtAddr;
 use page_table_entry::aarch64::A64PTE;
 
 use crate::{PageTable64, PagingMetaData};
@@ -13,6 +12,7 @@ impl PagingMetaData for A64PagingMetaData {
     const LEVELS: usize = 4;
     const PA_MAX_BITS: usize = 48;
     const VA_MAX_BITS: usize = 48;
+    type VirtAddr = memory_addr::VirtAddr;
 
     fn vaddr_is_valid(vaddr: usize) -> bool {
         let top_bits = vaddr >> Self::VA_MAX_BITS;
@@ -20,7 +20,7 @@ impl PagingMetaData for A64PagingMetaData {
     }
 
     #[inline]
-    fn flush_tlb(vaddr: Option<VirtAddr>) {
+    fn flush_tlb(vaddr: Option<memory_addr::VirtAddr>) {
         unsafe {
             if let Some(vaddr) = vaddr {
                 // TLB Invalidate by VA, All ASID, EL1, Inner Shareable

--- a/page_table_multiarch/src/arch/riscv.rs
+++ b/page_table_multiarch/src/arch/riscv.rs
@@ -1,11 +1,10 @@
 //! RISC-V specific page table structures.
 
 use crate::{PageTable64, PagingMetaData};
-use memory_addr::VirtAddr;
 use page_table_entry::riscv::Rv64PTE;
 
 #[inline]
-fn riscv_flush_tlb(vaddr: Option<VirtAddr>) {
+fn riscv_flush_tlb(vaddr: Option<memory_addr::VirtAddr>) {
     unsafe {
         if let Some(vaddr) = vaddr {
             riscv::asm::sfence_vma(0, vaddr.as_usize())
@@ -25,9 +24,10 @@ impl PagingMetaData for Sv39MetaData {
     const LEVELS: usize = 3;
     const PA_MAX_BITS: usize = 56;
     const VA_MAX_BITS: usize = 39;
+    type VirtAddr = memory_addr::VirtAddr;
 
     #[inline]
-    fn flush_tlb(vaddr: Option<VirtAddr>) {
+    fn flush_tlb(vaddr: Option<memory_addr::VirtAddr>) {
         riscv_flush_tlb(vaddr)
     }
 }
@@ -36,9 +36,10 @@ impl PagingMetaData for Sv48MetaData {
     const LEVELS: usize = 4;
     const PA_MAX_BITS: usize = 56;
     const VA_MAX_BITS: usize = 48;
+    type VirtAddr = memory_addr::VirtAddr;
 
     #[inline]
-    fn flush_tlb(vaddr: Option<VirtAddr>) {
+    fn flush_tlb(vaddr: Option<memory_addr::VirtAddr>) {
         riscv_flush_tlb(vaddr)
     }
 }

--- a/page_table_multiarch/src/arch/x86_64.rs
+++ b/page_table_multiarch/src/arch/x86_64.rs
@@ -1,7 +1,6 @@
 //! x86 specific page table structures.
 
 use crate::{PageTable64, PagingMetaData};
-use memory_addr::VirtAddr;
 use page_table_entry::x86_64::X64PTE;
 
 /// metadata of x86_64 page tables.
@@ -11,9 +10,10 @@ impl PagingMetaData for X64PagingMetaData {
     const LEVELS: usize = 4;
     const PA_MAX_BITS: usize = 52;
     const VA_MAX_BITS: usize = 48;
+    type VirtAddr = memory_addr::VirtAddr;
 
     #[inline]
-    fn flush_tlb(vaddr: Option<VirtAddr>) {
+    fn flush_tlb(vaddr: Option<memory_addr::VirtAddr>) {
         unsafe {
             if let Some(vaddr) = vaddr {
                 x86::tlb::flush(vaddr.into());


### PR DESCRIPTION
An associated type named `VirtAddr` is added to `PagingMetaData`. `PageTable64` has been updated. Not tested yet. @equation314 please review.