### PR TITLE
Fix entry present check in page table unmap & protect

### DIFF
--- a/page_table_multiarch/src/bits64.rs
+++ b/page_table_multiarch/src/bits64.rs
@@ -104,7 +104,7 @@ impl<M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> PageTable64<M, PTE, H
         flags: MappingFlags,
     ) -> PagingResult<(PageSize, TlbFlush<M>)> {
         let (entry, size) = self.get_entry_mut(vaddr)?;
-        if entry.is_unused() {
+        if !entry.is_present() {
             return Err(PagingError::NotMapped);
         }
         entry.set_flags(flags, size.is_huge());
@@ -117,7 +117,8 @@ impl<M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> PageTable64<M, PTE, H
     /// mapping is not present.
     pub fn unmap(&mut self, vaddr: M::VirtAddr) -> PagingResult<(PhysAddr, PageSize, TlbFlush<M>)> {
         let (entry, size) = self.get_entry_mut(vaddr)?;
-        if entry.is_unused() {
+        if !entry.is_present() {
+            entry.clear();
             return Err(PagingError::NotMapped);
         }
         let paddr = entry.paddr();


### PR DESCRIPTION
Otherwise there may be bugs when manipulate empty mappings on lazy mapping.