### PR TITLE
Do not link to alloc crate

### DIFF
--- a/page_table_multiarch/src/bits64.rs
+++ b/page_table_multiarch/src/bits64.rs
@@ -1,5 +1,3 @@
-extern crate alloc;
-
 use crate::{GenericPTE, PagingHandler, PagingMetaData};
 use crate::{MappingFlags, PageSize, PagingError, PagingResult, TlbFlush, TlbFlushAll};
 use core::marker::PhantomData;


### PR DESCRIPTION
The alloc crate is not used anywhere in the codebase, so do not link to it. This removes the requirement for downstream users to implement a global allocator, which might not be possible.