### PR TITLE
Add clear_copy_range mmethod

### DIFF
--- a/page_table_multiarch/src/bits64.rs
+++ b/page_table_multiarch/src/bits64.rs
@@ -324,13 +324,7 @@ impl<M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> PageTable64<M, PTE, H
         )
     }
 
-    /// Copy entries from another page table within the given virtual memory range.
-    pub fn copy_from(&mut self, other: &Self, start: M::VirtAddr, size: usize) {
-        if size == 0 {
-            return;
-        }
-        let src_table = self.table_of(other.root_paddr);
-        let dst_table = self.table_of_mut(self.root_paddr);
+    fn top_level_idx_range(&self, start: M::VirtAddr, size: usize) -> (usize, usize) {
         let index_fn = if M::LEVELS == 3 {
             p3_index
         } else if M::LEVELS == 4 {
@@ -342,7 +336,36 @@ impl<M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> PageTable64<M, PTE, H
         let end_idx = index_fn(start.into() + size - 1) + 1;
         assert!(start_idx < ENTRY_COUNT);
         assert!(end_idx <= ENTRY_COUNT);
+        (start_idx, end_idx)
+    }
+
+    /// Copy entries from another page table within the given virtual memory range.
+    pub fn copy_from(&mut self, other: &Self, start: M::VirtAddr, size: usize) {
+        if size == 0 {
+            return;
+        }
+        let src_table = self.table_of(other.root_paddr);
+        let dst_table = self.table_of_mut(self.root_paddr);
+        let (start_idx, end_idx) = self.top_level_idx_range(start, size);
         dst_table[start_idx..end_idx].copy_from_slice(&src_table[start_idx..end_idx]);
+    }
+
+    /// Undoes the copy of entries from another page table within the given
+    /// virtual memory range.
+    ///
+    /// This is the inverse operation of [`PageTable64::copy_from`]. It might be
+    /// useful when you need to drop a page table, but some of its entries are
+    /// copied from another actively used page table, so you need to unlink the
+    /// shared entries first.
+    pub fn clear_copy_range(&mut self, start: M::VirtAddr, size: usize) {
+        if size == 0 {
+            return;
+        }
+        let table = self.table_of_mut(self.root_paddr);
+        let (start_idx, end_idx) = self.top_level_idx_range(start, size);
+        for pte in &mut table[start_idx..end_idx] {
+            pte.clear();
+        }
     }
 }
 


### PR DESCRIPTION
Currently the page table can copy mappings from another page table using `copy_from`. `copy_from` will copy all first-level PTEs from the source.

However this could lead to undefined behavior if one page table gets dropped, while the other is still in use. In such case, the dropped page table will deallocate all frames, causing the other page table to use invalid frames.

This PR proposes a new API `clear_copy_range`. It will clear all first-level PTEs in the given virtual memory range. By remaining the main logic unchanged and adding this minimal new API to handle controls to users, we can mitigate this problem.