### PR TITLE
Fix invalid query result

### DIFF
--- a/page_table_multiarch/src/bits64.rs
+++ b/page_table_multiarch/src/bits64.rs
@@ -133,7 +133,7 @@ impl<M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> PageTable64<M, PTE, H
     /// mapping is not present.
     pub fn query(&self, vaddr: M::VirtAddr) -> PagingResult<(PhysAddr, MappingFlags, PageSize)> {
         let (entry, size) = self.get_entry(vaddr)?;
-        if entry.is_unused() {
+        if !entry.is_present() {
             return Err(PagingError::NotMapped);
         }
         let off = size.align_offset(vaddr.into());


### PR DESCRIPTION
`PageTable64::query` should use `is_present` to check if an entry is valid instead of `is_unused`.

This mainly affects RISC-V, LoongArch64 and Aarch64, because their `GenericPTE::new_page` implementations return a non-zero page table entry when called with a zero `PhysAddr` and an empty `MappingFlags`, thus `query` returns a `Ok((0x0, MappingFlags::empty(), PageSize))` instead of the expected `Err(PagingError::NotMapped)`.

This issue was previously discovered at https://github.com/oscomp/arceos/pull/10#issuecomment-2711340462 but was put aside while we thought of other ways to avoid creating invalid page table entries.