### PR TITLE
Add 'Debug' and 'LowerHex' constrains to PagingMetaData::VirtAddr.

### DIFF
--- a/page_table_multiarch/src/arch/riscv.rs
+++ b/page_table_multiarch/src/arch/riscv.rs
@@ -1,6 +1,7 @@
 //! RISC-V specific page table structures.
 
 use crate::{PageTable64, PagingMetaData};
+use core::fmt::{Debug, LowerHex};
 use page_table_entry::riscv::Rv64PTE;
 
 #[inline]
@@ -15,7 +16,7 @@ fn riscv_flush_tlb(vaddr: Option<memory_addr::VirtAddr>) {
 }
 
 /// A virtual address that can be used in RISC-V Sv39 and Sv48 page tables.
-pub trait SvVirtAddr: memory_addr::MemoryAddr + Send + Sync {
+pub trait SvVirtAddr: memory_addr::MemoryAddr + Debug + LowerHex + Send + Sync {
     /// Flush the TLB.
     fn flush_tlb(vaddr: Option<Self>);
 }

--- a/page_table_multiarch/src/lib.rs
+++ b/page_table_multiarch/src/lib.rs
@@ -8,7 +8,7 @@ extern crate log;
 mod arch;
 mod bits64;
 
-use core::{fmt::Debug, marker::PhantomData};
+use core::{fmt::Debug, fmt::LowerHex, marker::PhantomData};
 
 use memory_addr::{MemoryAddr, PhysAddr, VirtAddr};
 
@@ -54,7 +54,7 @@ pub trait PagingMetaData: Sync + Send {
     ///
     /// This associated type allows more flexible use of page tables structs like [`PageTable64`],
     /// for example, to implement EPTs.
-    type VirtAddr: MemoryAddr;
+    type VirtAddr: MemoryAddr + Debug + LowerHex;
     // (^)it can be converted from/to usize and it's trivially copyable
 
     /// Whether a given physical address is valid.


### PR DESCRIPTION
New repo 'aspace_generic' introduces the common generic type AddrSpace<PagingMetaData,PTE,H>.
This generic type needs 'PagingMetaData::VirtAddr' with extra 'Debug' and 'LowerHex' constrains to print debug info.