### PR TITLE
feat: copy and clear

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "memory_addr"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f769efcf10b9dfb4c913bebb409cda77b1a3f072b249bf5465e250bcb30eb49"
+checksum = "3d4054cba279515fa87761b101d857333ce06391dbe8f18a11347204a7111416"
 
 [[package]]
 name = "page_table_entry"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +73,7 @@ dependencies = [
 name = "page_table_multiarch"
 version = "0.5.3"
 dependencies = [
+ "bitmaps",
  "log",
  "memory_addr",
  "page_table_entry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,7 @@
 [workspace]
 resolver = "2"
 
-members = [
-    "page_table_multiarch",
-    "page_table_entry",
-]
+members = ["page_table_multiarch", "page_table_entry"]
 
 [workspace.package]
 version = "0.5.3"
@@ -17,3 +14,6 @@ repository = "https://github.com/arceos-org/page_table_multiarch"
 keywords = ["arceos", "paging", "page-table", "virtual-memory"]
 categories = ["os", "hardware-support", "memory-management", "no-std"]
 rust-version = "1.85"
+
+[workspace.dependencies]
+memory_addr = "0.4"

--- a/page_table_entry/Cargo.toml
+++ b/page_table_entry/Cargo.toml
@@ -17,7 +17,7 @@ arm-el2 = []
 
 [dependencies]
 bitflags = "2.6"
-memory_addr = "0.3"
+memory_addr.workspace = true
 
 [target.'cfg(any(target_arch = "aarch64", doc))'.dependencies]
 aarch64-cpu = "10.0"
@@ -26,4 +26,4 @@ aarch64-cpu = "10.0"
 x86_64 = "0.15.2"
 
 [package.metadata.docs.rs]
-rustc-args = [ "--cfg" , "doc"]
+rustc-args = ["--cfg", "doc"]

--- a/page_table_multiarch/Cargo.toml
+++ b/page_table_multiarch/Cargo.toml
@@ -12,10 +12,15 @@ keywords.workspace = true
 categories.workspace = true
 rust-version.workspace = true
 
+[features]
+default = []
+copy-from = ["dep:bitmaps"]
+
 [dependencies]
 log = "0.4"
 memory_addr.workspace = true
 page_table_entry = { path = "../page_table_entry", version = "0.5.2" }
+bitmaps = { version = "3.2", default-features = false, optional = true }
 
 [target.'cfg(any(target_arch = "x86_64", doc))'.dependencies]
 x86 = "0.52"

--- a/page_table_multiarch/Cargo.toml
+++ b/page_table_multiarch/Cargo.toml
@@ -14,7 +14,7 @@ rust-version.workspace = true
 
 [dependencies]
 log = "0.4"
-memory_addr = "0.3"
+memory_addr.workspace = true
 page_table_entry = { path = "../page_table_entry", version = "0.5.2" }
 
 [target.'cfg(any(target_arch = "x86_64", doc))'.dependencies]
@@ -24,4 +24,4 @@ x86 = "0.52"
 riscv = { version = "0.12", default-features = false }
 
 [package.metadata.docs.rs]
-rustc-args = [ "--cfg" , "doc"]
+rustc-args = ["--cfg", "doc"]

--- a/page_table_multiarch/src/bits64.rs
+++ b/page_table_multiarch/src/bits64.rs
@@ -532,14 +532,14 @@ impl<M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> PageTable64<M, PTE, H
         Ok(())
     }
 
-    fn dealloc_tree(&self, entry: &PTE, level: usize) {
+    fn dealloc_tree(&self, table_entry: &PTE, level: usize) {
         // don't free the entries in last level, they are not array.
         if level < M::LEVELS - 1 {
-            if let Ok(table) = self.next_table(entry) {
+            if let Ok(table) = self.next_table(table_entry) {
                 for entry in table {
                     self.dealloc_tree(entry, level + 1);
                 }
-                H::dealloc_frame(entry.paddr());
+                H::dealloc_frame(table_entry.paddr());
             }
         }
     }


### PR DESCRIPTION
This is an alternative to #15.

## Description

In this PR, a bitmap-based mask is added to `PageTable64` struct to prevent use-after-free or double-free issue when doing shallow copy with `copy_from`, marking the corresponding first-level PTEs as "borrowed".

As this addition will increase the size of `PageTable64` from 8 bytes to 80 bytes, I turn it into an optional feature. So it is a breaking change.

The other commit bumps the version of `memory_addr`.

## Additional information

Here is a document of some detailed analysis of this issue which may be useful: https://docs.qq.com/doc/DUGRReXdVRXVNbGdH