### PR TITLE
fix(aarch64): TLB flush VA bits

### DIFF
--- a/page_table_multiarch/src/arch/aarch64.rs
+++ b/page_table_multiarch/src/arch/aarch64.rs
@@ -24,7 +24,8 @@ impl PagingMetaData for A64PagingMetaData {
         unsafe {
             if let Some(vaddr) = vaddr {
                 // TLB Invalidate by VA, All ASID, EL1, Inner Shareable
-                asm!("tlbi vaae1is, {}; dsb sy; isb", in(reg) vaddr.as_usize())
+                const VA_MASK: usize = (1 << 44) - 1; // VA[55:12] => bits[43:0]
+                asm!("tlbi vaae1is, {}; dsb sy; isb", in(reg) ((vaddr.as_usize() >> 12) & VA_MASK))
             } else {
                 // TLB Invalidate by VMID, All at stage 1, EL1
                 asm!("tlbi vmalle1; dsb sy; isb")


### PR DESCRIPTION
This PR is a part of https://github.com/Starry-Mix-THU/page_table_multiarch/pull/2.

## Description

According to the [documentation](https://developer.arm.com/documentation/ddi0601/2025-03/AArch64-Instructions/TLBI-VAAE1IS--TLBI-VAAE1ISNXS--TLB-Invalidate-by-VA--All-ASID--EL1--Inner-Shareable), bits[43:0] of the argument for `TLBI VAAE1IS` match VA[55:12].