### PR TITLE
Fix `dealloc_tree` wrong starting level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "log",
  "memory_addr",
  "page_table_entry",
+ "rand",
  "riscv",
  "x86",
 ]
@@ -86,6 +87,21 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 
 [[package]]
 name = "raw-cpuid"

--- a/page_table_multiarch/Cargo.toml
+++ b/page_table_multiarch/Cargo.toml
@@ -30,3 +30,6 @@ riscv = { version = "0.14", default-features = false }
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "doc"]
+
+[dev-dependencies]
+rand = { version = "0.9.1", default-features = false, features = ["small_rng"] }

--- a/page_table_multiarch/src/bits64.rs
+++ b/page_table_multiarch/src/bits64.rs
@@ -350,7 +350,7 @@ impl<M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> PageTable64<M, PTE, H
         for i in start_idx..end_idx {
             let entry = &mut dst_table[i];
             if !self.borrowed_entries.set(i, true) {
-                self.dealloc_tree(entry, 1);
+                self.dealloc_tree(entry, 0);
             }
             *entry = src_table[i];
         }
@@ -554,7 +554,7 @@ impl<M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> Drop for PageTable64<
             if self.borrowed_entries.get(i) {
                 continue;
             }
-            self.dealloc_tree(entry, 1);
+            self.dealloc_tree(entry, 0);
         }
         H::dealloc_frame(self.root_paddr());
     }

--- a/page_table_multiarch/src/bits64.rs
+++ b/page_table_multiarch/src/bits64.rs
@@ -349,8 +349,8 @@ impl<M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> PageTable64<M, PTE, H
         assert!(end_idx <= ENTRY_COUNT);
         for i in start_idx..end_idx {
             let entry = &mut dst_table[i];
-            if !self.borrowed_entries.set(i, true) {
-                self.dealloc_tree(entry, 0);
+            if !self.borrowed_entries.set(i, true) && self.next_table(entry).is_ok() {
+                self.dealloc_tree(entry.paddr(), 1);
             }
             *entry = src_table[i];
         }
@@ -532,16 +532,16 @@ impl<M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> PageTable64<M, PTE, H
         Ok(())
     }
 
-    fn dealloc_tree(&self, table_entry: &PTE, level: usize) {
+    fn dealloc_tree(&self, table_paddr: PhysAddr, level: usize) {
         // don't free the entries in last level, they are not array.
         if level < M::LEVELS - 1 {
-            if let Ok(table) = self.next_table(table_entry) {
-                for entry in table {
-                    self.dealloc_tree(entry, level + 1);
+            for entry in self.table_of(table_paddr) {
+                if self.next_table(entry).is_ok() {
+                    self.dealloc_tree(entry.paddr(), level + 1);
                 }
-                H::dealloc_frame(table_entry.paddr());
             }
         }
+        H::dealloc_frame(table_paddr);
     }
 }
 
@@ -554,7 +554,9 @@ impl<M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> Drop for PageTable64<
             if self.borrowed_entries.get(i) {
                 continue;
             }
-            self.dealloc_tree(entry, 0);
+            if self.next_table(entry).is_ok() {
+                self.dealloc_tree(entry.paddr(), 1);
+            }
         }
         H::dealloc_frame(self.root_paddr());
     }

--- a/page_table_multiarch/tests/alloc_tests.rs
+++ b/page_table_multiarch/tests/alloc_tests.rs
@@ -1,0 +1,126 @@
+use std::{
+    alloc::{self, Layout},
+    cell::RefCell,
+    collections::HashSet,
+    marker::PhantomData,
+};
+
+use memory_addr::{PhysAddr, VirtAddr};
+use page_table_entry::{GenericPTE, MappingFlags};
+use page_table_multiarch::{PageSize, PageTable64, PagingHandler, PagingMetaData, PagingResult};
+use rand::{Rng, SeedableRng, rngs::SmallRng};
+
+const PAGE_LAYOUT: Layout = unsafe { Layout::from_size_align_unchecked(4096, 4096) };
+
+thread_local! {
+    static ALLOCATED: RefCell<HashSet<usize>> = RefCell::default();
+}
+struct TrackPagingHandler<M: PagingMetaData>(PhantomData<M>);
+impl<M: PagingMetaData> PagingHandler for TrackPagingHandler<M> {
+    fn alloc_frame() -> Option<PhysAddr> {
+        let ptr = unsafe { alloc::alloc(PAGE_LAYOUT) } as usize;
+        assert!(
+            ptr <= M::PA_MAX_ADDR,
+            "allocated frame address exceeds PA_MAX_ADDR"
+        );
+        ALLOCATED.with_borrow_mut(|it| it.insert(ptr));
+        Some(PhysAddr::from_usize(ptr))
+    }
+
+    fn dealloc_frame(paddr: PhysAddr) {
+        let ptr = paddr.as_usize();
+        ALLOCATED.with_borrow_mut(|it| {
+            assert!(it.remove(&ptr), "dealloc a frame that was not allocated");
+        });
+        unsafe {
+            alloc::dealloc(ptr as _, PAGE_LAYOUT);
+        }
+    }
+
+    fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
+        if paddr.as_usize() == 0 {
+            panic!();
+        }
+        VirtAddr::from_usize(paddr.as_usize())
+    }
+}
+
+fn run_test_for<M: PagingMetaData<VirtAddr = VirtAddr>, PTE: GenericPTE>() -> PagingResult<()> {
+    ALLOCATED.with_borrow_mut(|it| {
+        it.clear();
+    });
+
+    let vaddr_mask = ((1u64 << M::VA_MAX_BITS) - 1) & !0xfff;
+
+    let mut table = PageTable64::<M, PTE, TrackPagingHandler<M>>::try_new().unwrap();
+    let mut pages = HashSet::new();
+    let mut rng = SmallRng::seed_from_u64(1234);
+    for _ in 0..2048 {
+        if rng.random_ratio(3, 4) || pages.is_empty() {
+            // insert a mapping
+            let addr = loop {
+                let addr = rng.random::<u64>() & vaddr_mask;
+                if pages.insert(addr) {
+                    break addr;
+                }
+            };
+            table
+                .map(
+                    VirtAddr::from_usize(addr as usize),
+                    PhysAddr::from_usize((rng.random::<u64>() & vaddr_mask) as usize),
+                    PageSize::Size4K,
+                    MappingFlags::READ | MappingFlags::WRITE,
+                )?
+                .ignore();
+        } else {
+            // remove a mapping
+            let addr = *pages.iter().next().unwrap();
+            table.unmap(VirtAddr::from_usize(addr as usize))?.2.ignore();
+            pages.remove(&addr);
+        }
+    }
+
+    drop(table);
+    assert_eq!(
+        ALLOCATED.with_borrow(|it| it.len()),
+        0,
+        "Some frames were not deallocated"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_dealloc() -> PagingResult<()> {
+    #[cfg(target_arch = "x86_64")]
+    run_test_for::<
+        page_table_multiarch::x86_64::X64PagingMetaData,
+        page_table_entry::x86_64::X64PTE,
+    >()?;
+
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+    {
+        run_test_for::<
+            page_table_multiarch::riscv::Sv39MetaData<VirtAddr>,
+            page_table_entry::riscv::Rv64PTE,
+        >()?;
+        run_test_for::<
+            page_table_multiarch::riscv::Sv48MetaData<VirtAddr>,
+            page_table_entry::riscv::Rv64PTE,
+        >()?;
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    run_test_for::<
+        page_table_multiarch::aarch64::A64PagingMetaData,
+        page_table_entry::aarch64::A64PTE,
+    >()?;
+
+    #[cfg(target_arch = "loongarch64")]
+    run_test_for::<
+        page_table_multiarch::loongarch64::LA64MetaData,
+        page_table_entry::loongarch64::LA64PTE,
+    >()?;
+
+    Ok(())
+}


### PR DESCRIPTION
`dealloc_tree` introduced by #20 has wrong initial starting level. For instance, for a three-level page table, at most two levels of page table entries will be recycled (`level=1` and `level=2`), the last level will be skipped.