### PR TITLE
Handles absent entries with default page size

### DIFF
--- a/page_table_multiarch/src/bits64.rs
+++ b/page_table_multiarch/src/bits64.rs
@@ -551,10 +551,10 @@ impl<'a, M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> PageTable64Cursor
                     if entry.is_present() {
                         entry.set_flags(flags, page_size.is_huge());
                         self.push(vaddr);
-                    }
-                    // ignore if not present
-
-                    page_size
+                        page_size
+                    } else {
+                        PageSize::Size4K
+                    } // ignore if not present
                 }
                 Err(PagingError::NotMapped) => PageSize::Size4K,
                 Err(e) => {

--- a/page_table_multiarch/src/bits64.rs
+++ b/page_table_multiarch/src/bits64.rs
@@ -553,8 +553,9 @@ impl<'a, M: PagingMetaData, PTE: GenericPTE, H: PagingHandler> PageTable64Cursor
                         self.push(vaddr);
                         page_size
                     } else {
+                        // ignore if not present
                         PageSize::Size4K
-                    } // ignore if not present
+                    }
                 }
                 Err(PagingError::NotMapped) => PageSize::Size4K,
                 Err(e) => {


### PR DESCRIPTION
Ensures that a default 4K page size is returned when an entry is not present, avoiding potential underflow when the page size exceeds the remaining region.